### PR TITLE
fix: preemptive panic recovery

### DIFF
--- a/fraudserv/service.go
+++ b/fraudserv/service.go
@@ -177,7 +177,15 @@ func (f *ProofService[H]) processIncoming(
 	proofType fraud.ProofType,
 	from peer.ID,
 	msg *pubsub.Message,
-) pubsub.ValidationResult {
+) (res pubsub.ValidationResult) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			log.Errorf("PANIC while processing a proof: %s", err)
+			res = pubsub.ValidationReject
+		}
+	}()
+
 	ctx, span := tracer.Start(ctx, "process_proof", trace.WithAttributes(
 		attribute.String("proof_type", string(proofType)),
 	))

--- a/fraudserv/service_test.go
+++ b/fraudserv/service_test.go
@@ -19,6 +19,28 @@ import (
 	"github.com/celestiaorg/go-fraud/fraudtest"
 )
 
+func TestService_processIncomingRecovery(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+
+	serv := newTestService(ctx, t, false)
+	require.NoError(t, serv.Start(ctx))
+
+	fraud := fraudtest.NewPanickingProof[*headertest.DummyHeader]()
+	sub, err := serv.Subscribe(fraud.Type())
+	require.NoError(t, err)
+	defer sub.Cancel()
+
+	err = serv.Broadcast(ctx, fraud)
+	require.Error(t, err)
+
+	ctx2, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	t.Cleanup(cancel)
+
+	_, err = sub.Proof(ctx2)
+	require.Error(t, err)
+}
+
 func TestService_SubscribeBroadcastValid(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	t.Cleanup(cancel)

--- a/fraudtest/dummy_proof.go
+++ b/fraudtest/dummy_proof.go
@@ -11,15 +11,20 @@ import (
 const DummyProofType fraud.ProofType = "DummyProof"
 
 type DummyProof[H header.Header[H]] struct {
-	Valid bool
+	Valid  bool
+	Panics bool
 }
 
 func NewValidProof[H header.Header[H]]() *DummyProof[H] {
-	return &DummyProof[H]{true}
+	return &DummyProof[H]{true, false}
 }
 
 func NewInvalidProof[H header.Header[H]]() *DummyProof[H] {
-	return &DummyProof[H]{false}
+	return &DummyProof[H]{false, false}
+}
+
+func NewPanickingProof[H header.Header[H]]() *DummyProof[H] {
+	return &DummyProof[H]{false, true}
 }
 
 func (m *DummyProof[H]) Type() fraud.ProofType {
@@ -35,6 +40,9 @@ func (m *DummyProof[H]) Height() uint64 {
 }
 
 func (m *DummyProof[H]) Validate(H) error {
+	if m.Panics {
+		panic("crippling anxiety panic attack")
+	}
 	if !m.Valid {
 		return errors.New("DummyProof: proof is not valid")
 	}


### PR DESCRIPTION
This protects the library from potential dos vectors introduced by go-fraud users in the proof deserialization and verification code paths.