### PR TITLE
fix: MultiUnmarshaler.List method prealloc

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -11,7 +11,7 @@ type MultiUnmarshaler[H header.Header[H]] struct {
 }
 
 func (d MultiUnmarshaler[H]) List() []ProofType {
-	types := make([]ProofType, len(d.Unmarshalers))
+	types := make([]ProofType, 0, len(d.Unmarshalers))
 	for tp := range d.Unmarshalers {
 		types = append(types, tp)
 	}


### PR DESCRIPTION
## Overview

Make resulting slice of len 0, see https://go.dev/play/p/nYcpZxp45FD